### PR TITLE
Display vote history table

### DIFF
--- a/avalon.html
+++ b/avalon.html
@@ -27,6 +27,8 @@
     {{> score}}
     <br>
     {{> Template.dynamic template=whichView}}
+    <br>
+    {{> history}}
     <hr>
 
     {{> footer}}
@@ -423,4 +425,96 @@
     </p>
     {{> roleInfo}}
   </div>
+</template>
+
+<template name="history">
+  <table id="history">
+    <thead>
+      <tr>
+      {{#each players}}
+        <th><p>{{ name }}</p></th>
+      {{/each}}
+      </tr>
+    </thead>
+    {{#each rounds}}
+    <tbody>
+      {{#each votes}}
+      <tr class="{{status}}">
+        {{#each playerVotes}}
+        <td class="{{classList}}"></td>
+        {{/each}}
+      </tr>
+      {{/each}}
+      {{#if isCompleted}}
+      <tr class="summary {{result}}">
+        <td colspan="5">Mission {{round}} {{result}}ed with {{fails}} failures</td>
+      </tr>
+      {{/if}}
+    </tbody>
+    {{/each}}
+  </table>
+</template>
+
+<template name="test">
+  <table id="history">
+    <thead>
+      <th><p>Player 1</p></th>
+      <th><p>Player 2</p></th>
+      <th><p>Player 3</p></th>
+      <th><p>Player 4</p></th>
+      <th><p>Player 5</p></th>
+    </thead>
+    <tbody>
+      <tr class="reject">
+        <td class="leader chosen reject"></td>
+        <td class="reject"></td>
+        <td class="chosen accept"></td>
+        <td class="reject"></td>
+        <td class="accept"></td>
+      </tr>
+      <tr class="accept-pending">
+        <td class="chosen accept"></td>
+        <td class="leader accept"></td>
+        <td class="reject"></td>
+        <td class="reject"></td>
+        <td class="chosen accept"></td>
+      </tr>
+      <tr class="fail">
+        <td class="accept"></td>
+        <td class="chosen accept"></td>
+        <td class="leader chosen reject"></td>
+        <td class="reject"></td>
+        <td class="accept"></td>
+      </tr>
+      <tr class="summary fail">
+        <td colspan="5">Mission 1 failed with 2 failures</td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr class="pending">
+        <td class=""></td>
+        <td class=""></td>
+        <td class=""></td>
+        <td class="leader"></td>
+        <td class=""></td>
+      </tr>
+      <tr class="voting">
+        <td class="chosen"></td>
+        <td class=""></td>
+        <td class=""></td>
+        <td class=""></td>
+        <td class="leader chosen"></td>
+      </tr>
+      <tr class="pass">
+        <td class="leader accept"></td>
+        <td class="chosen accept"></td>
+        <td class="chosen reject"></td>
+        <td class="reject chosen"></td>
+        <td class="accept"></td>
+      </tr>
+      <tr class="summary pass">
+        <td colspan="5">Mission 2 passed</td>
+      </tr>
+    </tbody>
+  </table>
 </template>

--- a/avalon.html
+++ b/avalon.html
@@ -127,6 +127,7 @@
       <div class="game-options">
         <p class="options-header">Options</p>
         <div class="role-options">
+          <li class="checked"><input type="checkbox" class="displayHistory" checked="{{displayHistory}}"><span>show history table</span></li>
           <li class="checked"><input type="checkbox" class="merlin" checked="{{merlin}}"><span>Merlin</span></li>
           <li class="checked"><input type="checkbox" class="assassin" checked="{{assassin}}"><span>Assassin</span></li>
           <li class="checked"><input type="checkbox" class="morgana" checked="{{morgana}}"><span>Morgana</span></li>
@@ -428,6 +429,7 @@
 </template>
 
 <template name="history">
+  {{#if displayHistory}}
   <table id="history">
     <thead>
       <tr>
@@ -453,6 +455,7 @@
     </tbody>
     {{/each}}
   </table>
+  {{/if}}
 </template>
 
 <template name="test">

--- a/avalon.js
+++ b/avalon.js
@@ -149,6 +149,10 @@ if (Meteor.isClient) {
       Session.set("playerID", null);
       Session.set("gameID", null);
     },
+    "click .displayHistory":function () {
+      var game = getCurrentGame();
+      Games.update(game._id, {$set: {displayHistory: ! game.displayHistory}});
+    },
     "click .merlin":function () {
       var game = getCurrentGame();
       Games.update(game._id, {$set: {merlin: ! game.merlin}});
@@ -179,6 +183,9 @@ if (Meteor.isClient) {
       if (!game) { return null; }
       var players = Players.find({'gameID': game._id}, {'sort': {'ord': 1}}).fetch();
       return players;
+    },
+    displayHistory: function () {
+      return getCurrentGame().displayHistory;
     },
     merlin: function () {
       return getCurrentGame().merlin;
@@ -527,6 +534,10 @@ if (Meteor.isClient) {
   });
 
   Template.history.helpers({
+    displayHistory: function() {
+      var game = getCurrentGame();
+      return game != null && game.displayHistory;
+    },
     players: function() {
       return Players.find({'gameID': getCurrentGame()._id}, {'sort': {'ord': 1}});
     },
@@ -589,6 +600,7 @@ function generateNewGame() {
     round: 0,
     spyRoundsWon: 0,
     resRoundsWon: 0,
+    displayHistory: true,
   };
 
   var gameID = Games.insert(game);

--- a/avalon.js
+++ b/avalon.js
@@ -1,6 +1,11 @@
 Games = new Mongo.Collection("games");
-Rounds = new Mongo.Collection("rounds");
 Players = new Mongo.Collection("players");
+// A round is one of the 5 game rounds.
+Rounds = new Mongo.Collection("rounds");
+// Each round contains one or more votes.
+Votes = new Mongo.Collection("votes");
+// Each vote has a player vote from each player.
+PlayerVotes = new Mongo.Collection("playerVotes");
 
 if (Meteor.isClient) {
   Template.body.created = function () {
@@ -48,6 +53,9 @@ if (Meteor.isClient) {
         Session.set("playerID", player._id);
         Session.set("currentView", "lobby");
       });
+      Meteor.subscribe('rounds', game._id)
+      Meteor.subscribe('votes', game._id)
+      Meteor.subscribe('playerVotes', game._id)
 
       Tracker.autorun(trackGameState);
     }
@@ -90,6 +98,10 @@ if (Meteor.isClient) {
           Meteor.subscribe('players', game._id);
           player = generateNewPlayer(game, name);
 
+          Meteor.subscribe('rounds', game._id)
+          Meteor.subscribe('votes', game._id)
+          Meteor.subscribe('playerVotes', game._id)
+
           Session.set("gameID", game._id);
           Session.set("playerID", player._id);
           Session.set("currentView", "lobby");
@@ -108,7 +120,7 @@ if (Meteor.isClient) {
       var game = getCurrentGame();
       var players = Players.find({'gameID': game._id});
 
-      if (players.count() < 5) {
+      if (players.count() < 3) {
         $('.player-alert-5').show();
         $('.player-alert-10').hide();
         return false;
@@ -124,13 +136,18 @@ if (Meteor.isClient) {
       players = Players.find({'gameID': game._id}, {'sort': {'ord': 1}});
       assignTeams(players);
       assignSpecialRoles(players, game);
+      
+      generateNewRound(game, 0);
+
       Games.update(game._id, {$set: {state: 'rolePhase'}});
     },
     "click .button-leave":function () {
-      Games.update(getCurrentGame()._id, {$set: {numPlayers: game.numPlayers - 1}});
+      var game = getCurrentGame();
+      Games.update(game._id, {$set: {numPlayers: game.numPlayers - 1}});
       Session.set("currentView", "startMenu");
       Players.remove(getCurrentPlayer()._id);
       Session.set("playerID", null);
+      Session.set("gameID", null);
     },
     "click .merlin":function () {
       var game = getCurrentGame();
@@ -287,6 +304,17 @@ if (Meteor.isClient) {
       var numChosen = Players.find({'gameID': game._id, 'chosen': true}).count();
       var roundMax = missionNumPlayers(game.round, game.numPlayers)[0];
       if (numChosen == roundMax) {
+        var currentVote = getCurrentVote();
+        var chosen = [];
+        Players.find({'gameID': game._id, 'chosen': true})
+               .fetch()
+               .forEach(function (player) {
+          chosen.push(player.ord);
+          var pv = PlayerVotes.findOne({voteID: currentVote._id, ord: player.ord});
+          pv.classes.push("chosen");
+          PlayerVotes.update(pv._id, { $set: { chosen: true, classes: pv.classes } });
+        });
+        Votes.update(currentVote._id, { $set: { chosen: chosen, status: "voting" }});
         Games.update(game._id, {$set: {state: "votingPhase"}});
       }
     }
@@ -497,6 +525,27 @@ if (Meteor.isClient) {
       }, 5000);
     }
   });
+
+  Template.history.helpers({
+    players: function() {
+      return Players.find({'gameID': getCurrentGame()._id}, {'sort': {'ord': 1}});
+    },
+    rounds: function() {
+      return Rounds.find({gameID: getCurrentGame()._id}, {sort: {'round': 1}});
+    },
+    votes: function() {
+      return Votes.find({gameID: getCurrentGame()._id, roundID: this._id}, {sort: {'ord': 1}});
+    },
+    playerVotes: function() {
+      return PlayerVotes.find({gameID: getCurrentGame()._id, voteID: this._id}, {sort: {'ord': 1}});
+    },
+    classList: function() {
+      return this.classes.join(' ');
+    },
+    isCompleted: function() {
+      return this.result == "fail" || this.result == "pass";
+    },
+  });
 }
 
 if (Meteor.isServer) {
@@ -505,6 +554,8 @@ if (Meteor.isServer) {
     Games.remove({});
     Players.remove({});
     Rounds.remove({});
+    Votes.remove({});
+    PlayerVotes.remove({});
   });
 
   Meteor.publish('games', function(accessCode) {
@@ -513,6 +564,18 @@ if (Meteor.isServer) {
 
   Meteor.publish('players', function(gameID) {
     return Players.find({"gameID": gameID});
+  });
+
+  Meteor.publish('rounds', function(gameID) {
+    return Rounds.find({"gameID": gameID});
+  });
+
+  Meteor.publish('votes', function(gameID) {
+    return Votes.find({"gameID": gameID});
+  });
+
+  Meteor.publish('playerVotes', function(gameID) {
+    return PlayerVotes.find({"gameID": gameID});
   });
 }
 
@@ -523,9 +586,9 @@ function generateNewGame() {
     numPlayers: 0,
     state: "lobby",
     turn: 0,
-    round: 1,
+    round: 0,
     spyRoundsWon: 0,
-    resRoundsWon: 0
+    resRoundsWon: 0,
   };
 
   var gameID = Games.insert(game);
@@ -558,11 +621,75 @@ function generateNewPlayer(game, name) {
   return player;
 }
 
+function generateNewVote(game, round, leader) {
+  var vote = {
+    gameID: game._id,
+    roundID: round._id,
+    ord: Votes.find({roundID: round._id}).count(),
+    leader: leader,
+    status: "pending",
+  }
+  
+  var voteID = Votes.insert(vote);
+  var vote = Votes.findOne(voteID);
+
+  var players = Players.find({'gameID': game._id}, {'sort': {'ord': 1}});
+  players.forEach(function (player, index) {
+    var playerVote = {
+      gameID: game._id,
+      roundID: round._id,
+      voteID: voteID,
+      ord: player.ord,
+      classes: player.ord == leader ? ["leader"] : [],
+    }
+    PlayerVotes.insert(playerVote);
+  });
+}
+function generateNewRound(game, leader) {
+  var roundNum = game.round + 1;
+  Games.update(game._id, {$set: {round: roundNum}});
+
+  var round = {
+    gameID: game._id,
+    round: roundNum,
+    fails: null,
+    result: null,
+  };
+
+  var roundID = Rounds.insert(round);
+  var round = Rounds.findOne(roundID);
+
+  generateNewVote(game, round, leader);
+
+  return round;
+}
+
 function getCurrentGame() {
   var gameID = Session.get("gameID");
 
   if (gameID) {
     return Games.findOne(gameID);
+  }
+
+  return null;
+}
+
+function getCurrentRound() {
+  var game = getCurrentGame();
+
+  if (game) {
+    return Rounds.findOne({gameID: game._id, round: game.round});
+  }
+
+  return null;
+}
+
+function getCurrentVote() {
+  var round = getCurrentRound();
+  
+  if(round) {
+    var votes = Votes.find({'gameID': round.gameID, 'roundID': round._id}, { sort: {'ord': -1} }).fetch();
+    return votes[0];
   }
 
   return null;
@@ -692,6 +819,9 @@ function trackGameState() {
   }
 
   var game = Games.findOne(gameID);
+  if (!game) {
+    return;
+  }
   var player = Players.findOne(playerID);
   var players = Players.find({'gameID': game._id}, {'sort': {'ord': 1}});
   var leader = Players.findOne({
@@ -767,9 +897,14 @@ function trackPlayersState() {
       Games.update(game._id, {$set: {state: "pickPhase", turn: game.turn + 1, voteRejected: true }});
     }
   }
-  if (Session.get("currentView") === "missionPhase" && !!missionFinished(players)){
+  if (game.state === "missionPhase" && !!missionFinished(players)){
     handleMissionResult(missionFinished(players));
     resetAll(players);
+    // All players get here. Only run once.
+    if (getCurrentPlayer().ord == 0
+        && game.spyRoundsWon < 3 && game.resRoundsWon < 3) {
+      generateNewRound(game, game.turn % game.numPlayers);
+    }
   }
 }
 
@@ -812,9 +947,28 @@ function resetAll(players) {
 }
 
 function recordVotes(players) {
+  var currentVote = getCurrentVote();
+
   players.forEach(function (player) {
+    var pv = PlayerVotes.findOne({voteID: currentVote._id, ord: player.ord});
+    pv.classes.push(player.vote);
+    PlayerVotes.update(pv._id, { $set: { vote: player.vote, classes: pv.classes } });
+
     Players.update(player._id, { $set: { previousVote: player.vote }});
   });
+  // This function gets called for every player, but we only want to do
+  // this once.
+  if (getCurrentPlayer().ord == 0) {
+    if (allVoted(players) == "accept") {
+      Votes.update(currentVote._id, { $set: { status: "accept-pending" }});
+    } else {
+      Votes.update(currentVote._id, { $set: { status: "reject" }});
+
+      var game = getCurrentGame();
+      var newLeader = currentVote.leader + 1 % game.numPlayers;
+      generateNewVote(game, getCurrentRound(), newLeader);
+    }
+  }
 }
 
 function resetVotes(players) {
@@ -844,6 +998,11 @@ function missionFinished(players) {
   if (missionNumPlayers(game.round, game.numPlayers)[0] > (pass + fail)) {
     return false;
   } else {
+    var round = getCurrentRound();
+    var resString = fail < numToFail ? "pass" : "fail";
+    Rounds.update(round._id, { $set: { result: resString, fails: fail } });
+    var vote = getCurrentVote();
+    Votes.update(vote._id, { $set: { status: resString } });
     return ( fail >= numToFail ? fail : "pass");
   }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -228,3 +228,99 @@ hr.small-hr {
   margin-top: 10px;
   margin-bottom: 10px;
 }
+
+#history {
+  empty-cells: show;
+  background: purple;
+}
+
+#history thead th {
+  padding: 0;
+  padding-bottom: 0.2em;
+  width: 2em;
+  background: white;
+}
+#history thead th p {
+  -ms-writing-mode: tb-rl;
+  -webkit-writing-mode: vertical-rl;
+  -moz-writing-mode: vertical-rl;
+  -ms-writing-mode: vertical-rl;
+  writing-mode: vertical-rl;
+  text-align: end;
+  margin-left: auto;
+  margin-right: auto;
+  min-height: 5em;
+}
+#history tbody {
+  background: purple;
+}
+#history tbody td {
+  text-align: center;
+  /* TODO Why does this not fill the cell? */
+  font-size: 1em;
+  padding: 0;
+  margin: 0;
+}
+#history tbody td.accept:before {
+  color: green;
+  content: "\2713";
+}
+#history tbody td.reject:before {
+  color: brown;
+  content: "\2717";
+}
+#history tbody tr.pending {
+  background: #ffffcc;
+}
+#history tbody tr.voting {
+  background: #e3e3ab;
+}
+#history tbody tr.voting td.chosen {
+  background: #bbbb00;
+}
+#history tbody tr.reject {
+  background: #dddddd;
+}
+#history tbody tr.reject td.chosen {
+  background: #aaaaaa;
+}
+#history tbody tr.accept-pending {
+  background: #ffc799;
+}
+#history tbody tr.accept-pending td.chosen {
+  background: orange;
+}
+#history tbody tr.fail {
+  background: #e69e9e;
+}
+#history tbody tr.fail td.chosen {
+  background: #ff1616;
+}
+#history tbody tr.pass {
+  background: #ccccff;
+}
+#history tbody tr.pass td.chosen {
+  background: #6666ff;
+}
+#history tbody tr.summary.fail {
+  background: red;
+}
+#history tbody tr.summary.pass {
+  background: blue;
+}
+#history tbody td {
+  border: solid #e1e1e1 1px;
+  padding: 0;
+  width: 2em;
+  height: 2em;
+  min-width: 2em;
+  max-width: 2em;
+  min-height: 2em;
+  max-height: 2em;
+}
+#history tbody td.leader {
+  border-radius: 50%;
+}
+#history tbody td.chosen {
+  border: solid black 3px;
+}


### PR DESCRIPTION
Implementation of https://github.com/dperelman/avalon/issues/7 . The styles could probably use some work; they have not been tested on a mobile device.

The way the history tables are updated is a bit hacky: because the updates are not idempotent, the code just checks if the current player is 0 so it will only be run once. It would make much more sense for the code to just only be run once on the server, but I'm not sure how to express that in Meteor.