### PR TITLE
Fixed leaving a game from the lobby.

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -127,7 +127,8 @@ if (Meteor.isClient) {
       Games.update(game._id, {$set: {state: 'rolePhase'}});
     },
     "click .button-leave":function () {
-      Games.update(getCurrentGame()._id, {$set: {numPlayers: game.numPlayers - 1}});
+      var game = getCurrentGame();
+      Games.update(game._id, {$set: {numPlayers: game.numPlayers - 1}});
       Session.set("currentView", "startMenu");
       Players.remove(getCurrentPlayer()._id);
       Session.set("playerID", null);


### PR DESCRIPTION
There was a reference to `game` with initializing it to `getCurrentGame()`, so the "Leave Game" button didn't work.